### PR TITLE
Update Update-Account.ps1

### DIFF
--- a/Get Accounts/Update-Account.ps1
+++ b/Get Accounts/Update-Account.ps1
@@ -175,10 +175,20 @@ If (Test-CommandExists Invoke-RestMethod)
 		}
 		$arrProperties += $_bodyOp
 	}
+	
+	
+	#Format the body to send
+    	$body = $arrProperties | ConvertTo-Json -Depth 5
+    	If($body[0] -ne '[') 
+    	{
+    	$body = "[" + $body + "]"
+    	}
+    	$body
+	
 	Write-Host "Properties that will change in Account:" -ForegroundColor Cyan
 	$arrProperties | Select-Object @{Name='Property'; Expression={"{0} = {1}" -f $_.path, $_.value}}
 	try{
-		$UpdateAccountDetailsResponse = Invoke-RestMethod -Method Patch -Uri $($URL_AccountsDetails -f $AccountID) -Headers $logonHeader -Body ($arrProperties | ConvertTo-Json -Depth 5) -ContentType "application/json" -TimeoutSec 3600000
+		$UpdateAccountDetailsResponse = Invoke-RestMethod -Method Patch -Uri $($URL_AccountsDetails -f $AccountID) -Headers $logonHeader -Body ($body) -ContentType "application/json" -TimeoutSec 3600000
 		$response = $UpdateAccountDetailsResponse
 	} catch {
 		Write-Error $_.Exception.Response.StatusDescription


### PR DESCRIPTION
In case you want to update only one account property, you receive a Bad Request error. The cause is the wrongly-structured JSON.