### PR TITLE
Update-Account.ps1: Set operation "replace" for basic properties

### DIFF
--- a/Get Accounts/Update-Account.ps1
+++ b/Get Accounts/Update-Account.ps1
@@ -262,7 +262,8 @@ If (Test-CommandExists Invoke-RestMethod)
 		Else
 		# Handle Account basic properties
 		{
-			$_bodyOp.path = "/"+$param.Name
+			$_bodyOp.op    = "replace"
+			$_bodyOp.path  = "/"+$param.Name
 			$_bodyOp.value = $param.Value
 		}
 		$arrPropertiesBody += $_bodyOp


### PR DESCRIPTION
Was missing op: replace for "basic" things like username after the most recent change.