### PR TITLE
Fixing remoteMachineAddresses parsing in AOU

### DIFF
--- a/Account Onboard Utility/Accounts_Onboard_Utility.ps1
+++ b/Account Onboard Utility/Accounts_Onboard_Utility.ps1
@@ -317,10 +317,13 @@ Function New-AccountObject {
 			if ($_Account.secretManagement.automaticManagementEnabled -eq $false)
 			{ $_Account.secretManagement.manualManagementReason = $AccountLine.manualMgmtReason }
 		}
-		$_Account.remoteMachinesAccess = "" | Select-Object "remoteMachines", "accessRestrictedToRemoteMachines"
-		If(![String]::IsNullOrEmpty($AccountLine.remoteMachineAddresses)) {
-			$_Account.remoteMachinesAccess.remoteMachines = $AccountLine.remoteMachineAddresses
-			$_Account.remoteMachinesAccess.accessRestrictedToRemoteMachines = Convert-ToBool $AccountLine.restrictMachineAccessToList
+		if($AccountLine.PSobject.Properties.Name -contains "remoteMachineAddresses") {
+			if($null -eq $_Account.remoteMachinesAccess) { $_Account.remoteMachinesAccess = New-Object PSObject }
+			$_Account.remoteMachinesAccess | Add-Member -MemberType NoteProperty -Name "remoteMachines" -Value $AccountLine.remoteMachineAddresses
+		}
+		if($AccountLine.PSobject.Properties.Name -contains "restrictMachineAccessToList") {
+			if($null -eq $_Account.remoteMachinesAccess) { $_Account.remoteMachinesAccess = New-Object PSObject }
+			$_Account.remoteMachinesAccess | Add-Member -MemberType NoteProperty -Name "accessRestrictedToRemoteMachines" -Value $AccountLine.restrictMachineAccessToList
 		}
 		#endregion [Account object mapping]
 				


### PR DESCRIPTION
### Desired Outcome

This is to fix the parsing of the `remoteMachines` and `accessRestrictedToRemoteMachines` fields in AOU. Previously, an empty `$_Account.remoteMachinesAccess` object was created even if the fields were missing from the CSV, resulting in the script reseting these fields in CyberArk for every account:

```json
[{"op":"remove","path":"/remoteMachinesAccess/remoteMachines"},{"op":"remove","path":"/remoteMachinesAccess/accessRestrictedToRemoteMachines"}]
```

### Implemented Changes

Parsing logic was modified to only create the `$_Account.remoteMachinesAccess` object when there are corresponding fields in the CSV. This prevents unintentional account updates.

### Connected Issue/Story

N/A

### Definition of Done

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
