### PR TITLE
Fixed Safe Member update functionality

### DIFF
--- a/Migration via REST/Migrate.ps1
+++ b/Migration via REST/Migrate.ps1
@@ -190,7 +190,7 @@ if ($processFile){
         Write-Progress -Activity "Processing objects" -CurrentOperation "$counter of $($objects.count)" -PercentComplete (($counter / $objects.count)*100)
         }$srcAccount = Get-AccountDetail -url $SRCPVWAURL -logonHeader $srcToken -AccountID $object.id
         If ($($srcAccount.safename) -in $objectSafesToRemove){
-            Write-LogMessage -Type Debug -Msg "Safe $($srcMember.safename) is in the excluded safes list. Account with username of `"$($srcAccount.userName)`" with the address of `"$($srcAccount.address)`" will be skipped"
+            Write-LogMessage -Type Debug -Msg "Safe $($srcAccount.safename) is in the excluded safes list. Account with username of `"$($srcAccount.userName)`" with the address of `"$($srcAccount.address)`" will be skipped"
             continue
         }
 
@@ -246,7 +246,7 @@ if ($processFile){
                         Write-LogMessage -Type Debug -Msg "Safe Member $($srcMember.membername) is in the excluded owners list"
                     } Else{
                         if ($srcMember.membername -in $dstSafeMembers -or $("$($srcMember.memberName)@$dstUPN") -in $dstSafeMembers){
-                            $null = Update-SafeMember -url $DSTPVWAURL -logonHeader $dstToken -safe $($srcMember.safename) -safemember $srcMember -newLDAP $newLDAP 
+                            $null = Update-SafeMember -url $DSTPVWAURL -logonHeader $dstToken -safe $($srcAccount.safename) -safemember $srcMember -newLDAP $newLDAP 
                             Write-LogMessage -Type Debug -Msg "Safe Member `"$($srcMember.membername)`" updated on safe `"$($dstsafe.safename)`""
                         } else {
                             if ($srcMember.memberType -eq "User"){
@@ -255,12 +255,12 @@ if ($processFile){
                                 If (![string]::IsNullOrEmpty($dstUPN) -and ![string]::IsNullOrEmpty($userSource)){
                                     $srcMember.memberName = "$($srcMember.memberName)@$dstUPN"
                                 }
-                                $null = New-SafeMember -url $DSTPVWAURL -logonHeader $dstToken -safe $($srcMember.safename) -safemember $srcMember -newLDAP $newLDAP 
+                                $null = New-SafeMember -url $DSTPVWAURL -logonHeader $dstToken -safe $($srcAccount.safename) -safemember $srcMember -newLDAP $newLDAP 
                                 Write-LogMessage -Type Debug -Msg "Safe Member `"$($srcMember.membername)`" added  to safe `"$($dstsafe.safename)`""
                             } else {
                                 $groupSource = Get-GroupSource -url $SRCPVWAURL -logonHeader $srcToken -safemember $srcMember
                                 $srcMember | Add-Member NoteProperty searchIn $groupSource
-                                $null = New-SafeMember -url $DSTPVWAURL -logonHeader $dstToken -safe $($srcMember.safename) -safemember $srcMember -newLDAP $newLDAP 
+                                $null = New-SafeMember -url $DSTPVWAURL -logonHeader $dstToken -safe $($srcAccount.safename) -safemember $srcMember -newLDAP $newLDAP 
                             } 
                         }
                     }


### PR DESCRIPTION
In the code $srcMember.safemember is used, the member has no such property. Replaced it with $srcAccount.safemember coming from the exported csv

### Desired Outcome

*Please describe the desired outcome for this PR.  Said another way, what was
the original request that resulted in these code changes?  Feel free to copy
this information from the connected issue.*

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
