### PR TITLE
Fix for `psPASFormat` parameter for `Get-IdentityHeader` in `IdentityAuth.psm1`

### DIFF
--- a/Identity Authentication/IdentityAuth.psm1
+++ b/Identity Authentication/IdentityAuth.psm1
@@ -139,7 +139,8 @@ Function Get-IdentityHeader {
                 BaseURI         = $PCloudTenantAPIURL
                 ExternalVersion = "12.6.0"
                 WebSession      = $session
-            } | Add-ObjectDetail -TypeName psPAS.CyberArk.Vault.Session
+            }
+            $IdentityHeaders.PSObject.TypeNames.Insert(0, 'psPAS.CyberArk.Vault.Session')
         }
         Write-LogMessage -type "Verbose" -MSG "IdentityHeaders - $($IdentityHeaders |ConvertTo-Json)"
         return $identityHeaders

--- a/Identity Authentication/IdentityAuth.psm1
+++ b/Identity Authentication/IdentityAuth.psm1
@@ -1,19 +1,19 @@
 Function Get-IdentityHeader {
-    <#
-    .SYNOPSIS
-        Function to get Identity Header to enable running scripts using the token parameter. This will allow running the rest of the scripts in the directory for Identity Shared Services - Shared Services customers (ISPSS) (Privilege Cloud).
+    <# 
+    .SYNOPSIS 
+        Function to get Identity Header to enable running scripts using the token parameter. This will allow running the rest of the scripts in the directory for Identity Shared Services - Shared Services customers (ISPSS) (Privilege Cloud). 
         Token created using Identity documentation https://docs.cyberark.com/Product-Doc/OnlineHelp/PrivCloud-SS/Latest/en/Content/WebServices/ISP-Auth-APIs.htm
-
+    
     .DESCRIPTION
-        This function starts by requesting authentication into identity APIs. Once the process starts there can be multiple challenges that need to be responded with multiple options.
-        Each option is then being decided by the user. Once authentication is complete we get a token for the user to use for APIs within the ISPSS platform.
-
+        This function starts by requesting authentication into identity APIs. Once the process starts there can be multiple challenges that need to be responded with multiple options. 
+        Each option is then being decided by the user. Once authentication is complete we get a token for the user to use for APIs within the ISPSS platform. 
+    
     .PARAMETER IdentityTenantURL
         The URL of the tenant. you can find it if you go to Identity Admin Portal > constimization > Tenant URL.
-
+    
     .Parameter IdentityUserName
         The Username that will log into the system. It just needs the username, we will ask for PW, Push etc when doing the authentication.
-
+    
     #>
     [CmdletBinding()]
     Param (
@@ -37,7 +37,7 @@ Function Get-IdentityHeader {
             Mandatory = $false,
             HelpMessage = "PCloud Tenant API URL")]
         [string]$PCloudTenantAPIURL
-
+            
     )
     $ScriptFullPath = Get-Location
     $LOG_FILE_PATH = "$ScriptFullPath\IdentityAuth.log"
@@ -46,30 +46,30 @@ Function Get-IdentityHeader {
     $InVerbose = $PSBoundParameters.Verbose.IsPresent
 
     #Platform Identity API
-
+    
     if($IdentityTenantURL -match "https://"){
         $IdaptiveBasePlatformURL = $IdentityTenantURL
     } Else{
         $IdaptiveBasePlatformURL = "https://$IdentityTenantURL"
     }
-
+    
     Write-LogMessage -type "Verbose" -MSG "URL used : $($IdaptiveBasePlatformURL|ConvertTo-Json)"
-
+    
     #Creating URLs
-
+    
     $IdaptiveBasePlatformSecURL = "$IdaptiveBasePlatformURL/Security"
     $startPlatformAPIAuth = "$IdaptiveBasePlatformSecURL/StartAuthentication"
     $startPlatformAPIAdvancedAuth = "$IdaptiveBasePlatformSecURL/AdvanceAuthentication"
     $LogoffPlatform = "$IdaptiveBasePlatformSecURL/logout"
-
+    
     #Creating the username/password variables
-
+    
     $startPlatformAPIBody = @{TenantId = $IdentityTenantId; User = $IdentityUserName ; Version = "1.0"} | ConvertTo-Json -Compress
     Write-LogMessage -type "Verbose" -MSG "URL body : $($startPlatformAPIBody|ConvertTo-Json)"
-
+    
     $IdaptiveResponse = Invoke-RestMethod -Uri $startPlatformAPIAuth -Method Post -ContentType "application/json" -Body $startPlatformAPIBody -TimeoutSec 30
     Write-LogMessage -type "Verbose" -MSG "IdaptiveResponse : $($IdaptiveResponse|ConvertTo-Json)"
-
+    
     # We can use the following to give info to the customer $IdaptiveResponse.Result.Challenges.mechanisms
     $j = 1
     $SessionId = $($IdaptiveResponse.Result.SessionId)
@@ -82,7 +82,7 @@ Function Get-IdentityHeader {
         $startPlatformAPIAdvancedAuthBody = $null
         $ChallengeCount = 0
         $ChallengeCount = $challenge.mechanisms.count
-
+    
         Write-LogMessage -type "Info" -MSG "Challenge $($j):"
         #Multi mechanisms option response
         If ($ChallengeCount -gt 1) {
@@ -99,7 +99,7 @@ Function Get-IdentityHeader {
             #Requesting to know which option the user wants to use
             $Option = $Null
             While ($Option -gt $ChallengeCount -or $Option -lt 1 -or $Option -eq $Null) {
-                $Option = Read-Host "Please enter the option number you want to use. from 1-$ChallengeCount"
+                $Option = Read-Host "Please enter the option number you want to use. from 1-$ChallengeCount" 
                 Try {
                     $Option = [Int]$Option
                 } Catch {
@@ -111,7 +111,7 @@ Function Get-IdentityHeader {
             #Completing step of authentication
             $AnswerToResponse = Invoke-AdvancedAuthBody -SessionId $SessionId -Mechanism $Mechanism -IdentityTenantId $IdentityTenantId
             Write-LogMessage -type "Verbose" -MSG "AnswerToResponce - $($AnswerToResponse |ConvertTo-Json)"
-        }
+        } 
         #One mechanism
         Else {
             $Mechanism = $challenge.mechanisms
@@ -121,7 +121,7 @@ Function Get-IdentityHeader {
             $AnswerToResponse = Invoke-AdvancedAuthBody -SessionId $SessionId -Mechanism $Mechanism -IdentityTenantId $IdentityTenantId
             Write-LogMessage -type "Verbose" -MSG "AnswerToResponce - $($AnswerToResponse |ConvertTo-Json)"
         }
-        #Need Better logic here to make sure that we are done with all the challenges correctly and got next challenge.
+        #Need Better logic here to make sure that we are done with all the challenges correctly and got next challenge.  
         $j=$j+1 #incrementing the challenge number
     }
     If ($AnswerToResponse.success){
@@ -139,19 +139,18 @@ Function Get-IdentityHeader {
                 BaseURI         = $PCloudTenantAPIURL
                 ExternalVersion = "12.6.0"
                 WebSession      = $session
-            }
-            $IdentityHeaders.PSObject.TypeNames.Insert(0, 'psPAS.CyberArk.Vault.Session')
+            } | Add-ObjectDetail -TypeName psPAS.CyberArk.Vault.Session
         }
         Write-LogMessage -type "Verbose" -MSG "IdentityHeaders - $($IdentityHeaders |ConvertTo-Json)"
         return $identityHeaders
     }
     else {
-        Write-LogMessage -type "Verbose" -MSG "identityHeaders: $($AnswerToResponse|ConvertTo-Json)"
-        Write-LogMessage -type Error -MSG "Error during logon : $($AnswerToResponse.Message)"
+        Write-LogMessage -type "Verbose" -MSG "identityHeaders: $($AnswerToResponse|ConvertTo-Json)" 
+        Write-LogMessage -type Error -MSG "Error during logon : $($AnswerToResponse.Message)" 
     }
 }
-
-
+    
+    
 #Runs an advanceAuth API. It will wait in the loop if needed
 Function Invoke-AdvancedAuthBody {
     [CmdletBinding()]
@@ -175,42 +174,42 @@ Function Invoke-AdvancedAuthBody {
         #We got two options here 1 text and one Push notification. We will need to do the while statement in this option.
         $Action = "StartOOB"
         $startPlatformAPIAdvancedAuthBody = @{TenantID = $IdentityTenantId; SessionId = $SessionId; MechanismId = $MechanismId; Action = $Action; } | ConvertTo-Json -Compress
-        Write-LogMessage -type "Verbose" -MSG "startPlatformAPIAdvancedAuthBody: $($startPlatformAPIAdvancedAuthBody|ConvertTo-Json)"
+        Write-LogMessage -type "Verbose" -MSG "startPlatformAPIAdvancedAuthBody: $($startPlatformAPIAdvancedAuthBody|ConvertTo-Json)" 
         Write-LogMessage -type "Info" -MSG "Waiting for Push to be pressed"
     } ElseIf ($Mechanism.AnswerType -eq "Text") {
         $Action = "Answer"
         $Answer = Read-Host "Please enter the answer from the challenge type" -AsSecureString
         $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Answer)
         $startPlatformAPIAdvancedAuthBody = @{TenantID = $IdentityTenantId; SessionId = $SessionId; MechanismId = $MechanismId; Action = $Action; Answer = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR))} | ConvertTo-Json -Compress
-        Write-LogMessage -type "Verbose" -MSG "startPlatformAPIAdvancedAuthBody: $($startPlatformAPIAdvancedAuthBody|ConvertTo-Json)"
+        Write-LogMessage -type "Verbose" -MSG "startPlatformAPIAdvancedAuthBody: $($startPlatformAPIAdvancedAuthBody|ConvertTo-Json)" 
     }
     #Rest API
     Try {
         $AnswerToResponse = Invoke-RestMethod -Uri $startPlatformAPIAdvancedAuth -Method Post -ContentType "application/json" -Body $startPlatformAPIAdvancedAuthBody -TimeoutSec 30
-        Write-LogMessage -type "Verbose" -MSG "AnswerToResponse: $($AnswerToResponse|ConvertTo-Json)"
+        Write-LogMessage -type "Verbose" -MSG "AnswerToResponse: $($AnswerToResponse|ConvertTo-Json)" 
     } Catch {
-        Write-LogMessage -Type Error -MSG $_.ErrorDetails.Message
+        Write-LogMessage -Type Error -MSG $_.ErrorDetails.Message  
     }
     while ($AnswerToResponse.Result.Summary -eq "OobPending") {
         Start-Sleep -Seconds 2
         $pollBody = @{TenantID = $IdentityTenantId; SessionId = $SessionId; MechanismId = $MechanismId; Action = "Poll"; } | ConvertTo-Json -Compress
-        Write-LogMessage -type "Verbose" -MSG "pollBody: $($pollBody|ConvertTo-Json)"
+        Write-LogMessage -type "Verbose" -MSG "pollBody: $($pollBody|ConvertTo-Json)" 
         $AnswerToResponse = Invoke-RestMethod -Uri $startPlatformAPIAdvancedAuth -Method Post -ContentType "application/json" -Body $pollBody -TimeoutSec 30
-        Write-LogMessage -type "Verbose" -MSG "AnswerToResponse: $($AnswerToResponse|ConvertTo-Json)"
+        Write-LogMessage -type "Verbose" -MSG "AnswerToResponse: $($AnswerToResponse|ConvertTo-Json)" 
         Write-LogMessage -type "Info" -MSG "$($AnswerToResponse.Result.Summary)"
     }
     $AnswerToResponse
 }
-
+    
 Function Write-LogMessage {
-    <#
-    .SYNOPSIS
+    <# 
+    .SYNOPSIS 
         Method to log a message on screen and in a log file
-
+    
     .DESCRIPTION
-        Logging The input Message to the Screen and the Log File.
+        Logging The input Message to the Screen and the Log File. 
         The Message Type is presented in colours on the screen based on the type
-
+    
     .PARAMETER LogFile
         The Log File to write to. By default using the LOG_FILE_PATH
     .PARAMETER MSG
@@ -240,17 +239,17 @@ Function Write-LogMessage {
         [ValidateSet("Info", "Warning", "Error", "Debug", "Verbose", "Success", "LogOnly")]
         [String]$type = "Info",
         [Parameter(Mandatory = $false)]
-        [String]$LogFile = $LOG_FILE_PATH
+        [String]$LogFile = $LOG_FILE_PATH 
     )
     Try {
         If ($Header) {
-            "=======================================" | Out-File -Append -FilePath $LogFile
+            "=======================================" | Out-File -Append -FilePath $LogFile 
             Write-Host "=======================================" -ForegroundColor Magenta
-        } ElseIf ($SubHeader) {
-            "------------------------------------" | Out-File -Append -FilePath $LogFile
+        } ElseIf ($SubHeader) { 
+            "------------------------------------" | Out-File -Append -FilePath $LogFile 
             Write-Host "------------------------------------" -ForegroundColor Magenta
         }
-
+            
         $msgToWrite = "[$(Get-Date -Format "yyyy-MM-dd hh:mm:ss")]`t"
         if ($InDebug -or $InVerbose) {
             $writeToFile = $true
@@ -259,20 +258,20 @@ Function Write-LogMessage {
         }
         # Replace empty message with 'N/A'
         if ([string]::IsNullOrEmpty($Msg)) { $Msg = "N/A" }
-
+            
         # Mask Passwords
         if ($Msg -match '((?:password|credentials|secret)\s{0,}["\:=]{1,}\s{0,}["]{0,})(?=([\w`~!@#$%^&*()-_\=\+\\\/|;:\.,\[\]{}]+))') {
             $Msg = $Msg.Replace($Matches[2], "****")
         }
         # Check the message type
         switch ($type) {
-            { ($_ -eq "Info") -or ($_ -eq "LogOnly") } {
+            { ($_ -eq "Info") -or ($_ -eq "LogOnly") } { 
                 If ($_ -eq "Info") {
                     Write-Host $MSG.ToString() -ForegroundColor $(If ($Header -or $SubHeader) { "magenta" } Elseif ($Early) { "DarkGray" } Else { "White" })
                 }
                 $msgToWrite += "[INFO]`t$Msg"
             }
-            "Success" {
+            "Success" { 
                 Write-Host $MSG.ToString() -ForegroundColor Green
                 $msgToWrite += "[SUCCESS]`t$Msg"
             }
@@ -284,14 +283,14 @@ Function Write-LogMessage {
                 Write-Host $MSG.ToString() -ForegroundColor Red
                 $msgToWrite += "[ERROR]`t$Msg"
             }
-            "Debug" {
+            "Debug" { 
                 if ($InDebug -or $InVerbose) {
                     $writeToFile = $true
                     Write-Debug $MSG
                     $msgToWrite += "[DEBUG]`t$Msg"
                 } else { $writeToFile = $False }
             }
-            "Verbose" {
+            "Verbose" { 
                 if ($InVerbose) {
                     $writeToFile = $true
                     Write-Verbose -Msg $MSG
@@ -299,10 +298,10 @@ Function Write-LogMessage {
                 } else { $writeToFile = $False }
             }
         }
-
+    
         If ($writeToFile) { $msgToWrite | Out-File -Append -FilePath $LogFile }
-        If ($Footer) {
-            "=======================================" | Out-File -Append -FilePath $LogFile
+        If ($Footer) { 
+            "=======================================" | Out-File -Append -FilePath $LogFile 
             Write-Host "=======================================" -ForegroundColor Magenta
         }
     } catch {


### PR DESCRIPTION
### Desired Outcome

This PR changes the way `Get-IdentityHeader` in `IdentityAuth.psm1` creates a `psPAS.CyberArk.Vault.Session` by using $Object.PSObject.TypeNames instead of the private function `Add-ObjectDetail` from `psPAS`.

### Implemented Changes

The parameter `psPASFormat` for `IdentityAuth.psm1` now works as it does not use a private function.

### Connected Issue/Story

Resolves #321 

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
