### PR TITLE
Retrieve real version of PCloud tenant as part of `psPASFormat` parameter for `Get-IdentityHeader` in `IdentityAuth.psm1`

### DIFF
--- a/Identity Authentication/IdentityAuth.psm1
+++ b/Identity Authentication/IdentityAuth.psm1
@@ -130,6 +130,8 @@ Function Get-IdentityHeader {
             $IdentityHeaders = @{Authorization = "Bearer $($AnswerToResponse.Result.Token)"}
             $IdentityHeaders.Add("X-IDAP-NATIVE-CLIENT","true")
         } else {
+            $ExternalVersion = Get-PCloudExternalVersion -PCloudTenantAPIURL $PCloudTenantAPIURL -Token $AnswerToResponse.Result.Token
+
             $header = New-Object System.Collections.Generic.Dictionary"[String,string]"
             $header.add("Authorization","Bearer $($AnswerToResponse.Result.Token)")
             $session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
@@ -137,7 +139,7 @@ Function Get-IdentityHeader {
             $IdentityHeaders = [PSCustomObject]@{
                 User            = $IdentityUserName
                 BaseURI         = $PCloudTenantAPIURL
-                ExternalVersion = "12.6.0"
+                ExternalVersion = $ExternalVersion
                 WebSession      = $session
             } | Add-ObjectDetail -TypeName psPAS.CyberArk.Vault.Session
         }
@@ -199,6 +201,29 @@ Function Invoke-AdvancedAuthBody {
         Write-LogMessage -type "Info" -MSG "$($AnswerToResponse.Result.Summary)"
     }
     $AnswerToResponse
+}
+
+function Get-PCloudExternalVersion {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        $PCloudTenantApiUrl,
+        [Parameter(Mandatory = $true)]
+        $Token
+    )
+
+    $ExternalVersion = "12.6.0"
+    try {
+        $Headers = @{
+            Authorization = "Bearer $Token"
+        }
+        $Response = Invoke-RestMethod -Method GET -Uri "$PCloudTenantApiUrl/WebServices/PIMServices.svc/Server" -Headers $Headers -ContentType 'application/json'
+        $ExternalVersion = $Response.ExternalVersion
+    } catch {
+        Write-LogMessage -Type Error -MSG $_.ErrorDetails.Message
+    }
+
+    $ExternalVersion
 }
     
 Function Write-LogMessage {


### PR DESCRIPTION
### Desired Outcome

Currently the version used when creating a `psPAS.CyberArk.Vault.Session` is hardcoded to be 12.6. The `psPAS` module uses this property to determine if the PAS version has the needed functionality. This PR makes it so the real version of the PCloud tenant is used as the `ExternalVersion` property when creating `psPAS.CyberArk.Vault.Session`.

### Implemented Changes

The function now retrieves the real `ExternalVersion` of the PCloud tenant and uses it when creating the `psPAS.CyberArk.Vault.Session` object.

### Connected Issue/Story

n/a

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
