### PR TITLE
Log off Session if token is not passed

### DIFF
--- a/Safe Management/Safe-Management.ps1
+++ b/Safe Management/Safe-Management.ps1
@@ -1271,7 +1271,7 @@ If (Test-CommandExists Invoke-RestMethod) {
     # Logoff the session
     # ------------------
 
-    If ([string]::IsNullOrEmpty($logonToken)) {
+    If (![string]::IsNullOrEmpty($logonToken)) {
         Write-Host "LogonToken passed, session NOT logged off"
     }
     else {


### PR DESCRIPTION
### Desired Outcome

Log off the session if the script is run without passing a token as a parameter. If it is passed a token, do not log off the session.

### Implemented Changes

- Adding a not operator in front of the conditional expression, to log off the session if the token is not passed to the script and the user has authenticated inside the script. 
- Without the not operator, the session will not log off when the user has authenticated inside of the script.
- Please test running the script and authenticate within the script. See if the session is properly logged off

### Connected Issue/Story

NA

### Definition of Done
- The session is logged off after the desired operations are completed, when the user authenticates within the script

#### Changelog

- [N] The CHANGELOG has been updated, or
- [Y] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [N] This PR includes new unit and integration tests to go with the code
  changes, or
- [N] The changes in this PR do not require tests

#### Documentation

- [N] Docs (e.g. `README`s) were updated in this PR
- [N] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [Y] This PR does not require updating any documentation

#### Behavior

- [N] This PR changes product behavior and has been reviewed by a PO, or
- [N] These changes are part of a larger initiative that will be reviewed later, or
- [Y] No behavior was changed with this PR

#### Security

- [N] Security architect has reviewed the changes in this PR,
- [N] These changes are part of a larger initiative with a separate security review, or
- [N] There are no security aspects to these changes
