### PR TITLE
don't set a null value

### DIFF
--- a/Account Onboard Utility/Accounts_Onboard_Utility.ps1
+++ b/Account Onboard Utility/Accounts_Onboard_Utility.ps1
@@ -970,12 +970,14 @@ The Good record to output
 #>
 
 	try {
-		$global:workAccount.Password = $null
+ 		If ($null -ne $global:workAccount.Password){
+			$global:workAccount.Password = $null
+   		}
 		$global:workAccount | Export-Csv -Append -NoTypeInformation $csvPathGood
 		Write-LogMessage -Type Debug -MSG "Outputted good record to CSV"
 		Write-LogMessage -Type Verbose -MSG "Good Record: $global:workAccount"
 	} catch {
-		Write-LogMessage -Type Error -MSG "Unable to outout good record to file: $csvPathGood"
+		Write-LogMessage -Type Error -MSG "Unable to output good record to file: $csvPathGood"
 		Write-LogMessage -Type Verbose -MSG "Good Record: $global:workAccount"
 
 	}		


### PR DESCRIPTION
if the $global:workAccount.Password is null, don't set it to null. Otherwise it will fail and the good.csv will not be written.

This will happen when the csv does not have a password value. I.e: for update operations.



