### PR TITLE
Fix bug in Safe-Management.ps1 -> Get-Safe

### DIFF
--- a/Safe Management/Safe-Management.ps1
+++ b/Safe Management/Safe-Management.ps1
@@ -641,7 +641,6 @@ Get-Safe -safeName "x0-Win-S-Admins"
     try {
         $accSafeURL = $URL_SpecificSafe -f $(ConvertTo-URL $safeName)
         $_safe += $(Invoke-Rest -Uri $accSafeURL -Command 'Get' -Header $g_LogonHeader -ErrAction 'SilentlyContinue')
-        $_safe += $(Invoke-Rest -Uri $accSafeURL -Command 'Get' -Header $g_LogonHeader -ErrAction 'SilentlyContinue')
         If (![string]::IsNullOrEmpty($_safe.nextLink)) {
             $nextLink = $_safe.nextLink
             While (![string]::IsNullOrEmpty($nextLink)) {

--- a/Safe Management/Safe-Management.ps1
+++ b/Safe Management/Safe-Management.ps1
@@ -646,7 +646,7 @@ Get-Safe -safeName "x0-Win-S-Admins"
             $nextLink = $_safe.nextLink
             While (![string]::IsNullOrEmpty($nextLink)) {
                 $_safeNext = @()
-                $_safeNext += $(Invoke-Rest-Uri "$PVWAURL/$nextLink" -Command 'Get' -Header $g_LogonHeader -ErrAction 'SilentlyContinue')
+                $_safeNext += $(Invoke-Rest -Uri "$PVWAURL/$nextLink" -Command 'Get' -Header $g_LogonHeader -ErrAction 'SilentlyContinue')
                 $_safe += $_safeNext
                 If (![string]::IsNullOrEmpty($_safeNext.nextLink)) {
                     $nextLink = $_safeNext.nextLink
@@ -669,9 +669,9 @@ Get-Safe -safeName "x0-Win-S-Admins"
             Write-LogMessage -type Error -MSG "Status Description: $($_.Exception.Response.StatusDescription)"
         }
     }
-    catch {
-        Throw $(New-Object System.Exception ("Get-Safe: Error retrieving safe '$safename' details.", $_.Exception))
-    }
+    # catch {
+    #     Throw $(New-Object System.Exception ("Get-Safe: Error retrieving safe '$safename' details.", $_.Exception))
+    # }
 
     return $_safe
 }

--- a/Safe Management/Safe-Management.ps1
+++ b/Safe Management/Safe-Management.ps1
@@ -668,9 +668,9 @@ Get-Safe -safeName "x0-Win-S-Admins"
             Write-LogMessage -type Error -MSG "Status Description: $($_.Exception.Response.StatusDescription)"
         }
     }
-    # catch {
-    #     Throw $(New-Object System.Exception ("Get-Safe: Error retrieving safe '$safename' details.", $_.Exception))
-    # }
+    catch {
+        Throw $(New-Object System.Exception ("Get-Safe: Error retrieving safe '$safename' details.", $_.Exception))
+    }
 
     return $_safe
 }


### PR DESCRIPTION
Script failed due to two issues introduced in the latest merge:

1: Duplicate line #643 `$_safe += $(Invoke-Rest -Uri $accSafeURL -Command 'Get' -Header $g_LogonHeader -ErrAction 'SilentlyContinue')`.
This caused the code a few lines down to find two .nextlink values and build an incorrect `$_safeNext`.
2: Line # 648  was missing the space in `Invoke-Rest -Uri`

## Testing ##
Safe-Management -List has been run with -Verbose and confirmed all requests and output are as expected.