### PR TITLE
Fix psPAS session token format

### DIFF
--- a/Identity Authentication/IdentityAuth.psm1
+++ b/Identity Authentication/IdentityAuth.psm1
@@ -522,10 +522,18 @@ function Format-Token {
         $session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
         $session.Headers = $IdentityHeaders
         $IdentityHeaders = [PSCustomObject]@{
-            User            = $IdentityUserName
-            BaseURI         = $PCloudTenantAPIURL
-            ExternalVersion = $ExternalVersion
-            WebSession      = $session
+            User               = $IdentityUserName
+            BaseURI            = $PCloudTenantAPIURL
+            ApiURI             = "https://$PCloudSubdomain.privilegecloud.cyberark.cloud"
+            ExternalVersion    = $ExternalVersion
+            WebSession         = $session
+            StartTime          = $null
+            ElapsedTime        = $null
+            LastCommand        = $null
+            LastCommandTime    = $null
+            LastCommandResults = $null
+            LastError          = $null
+            LastErrorTime      = $null
         }
         $IdentityHeaders.PSObject.TypeNames.Insert(0, 'psPAS.CyberArk.Vault.Session')
     }


### PR DESCRIPTION
When using the IdentityAuth module to create headers for use in psPAS it will not work as the latest version of psPAS is looking for additional members in the ```$session``` object that is created. https://github.com/pspete/psPAS/blob/4f44ad552862c4b0b8de333993f058a1b394c40c/psPAS/psPAS.psm1#L60-L71

Here is an example without the fix:

```
# laroberts in wksta
 ➜  Import-Module C:\users\laroberts\Downloads\IdentityAuth_bad.psm1
# laroberts in wksta
 ➜  $header = Get-IdentityHeader -IdentityTenantURL "REDACTED.id.cyberark.cloud" -psPASFormat -PCloudSubdomain "REDACTED" -IdentityUserName "REDACTED@REDACTED.com"
Identity Token Set Successfully
# laroberts in wksta
 ➜  Use-PASSession $header
# laroberts in wksta
 ➜  Get-PASUser
Exception setting "LastCommand": "The property 'LastCommand' cannot be found on this object. Verify that the property exists and can be set."
At line:382 char:4
+             $psPASSession.LastCommand = Get-ParentFunction | Select-O ...
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], SetValueInvocationException
    + FullyQualifiedErrorId : ExceptionWhenSetting

Exception setting "LastCommandResults": "The property 'LastCommandResults' cannot be found on this object. Verify that the property exists and can be set."
At line:383 char:4
+             $psPASSession.LastCommandResults = $APIResponse
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], SetValueInvocationException
    + FullyQualifiedErrorId : ExceptionWhenSetting

Exception setting "LastCommandTime": "The property 'LastCommandTime' cannot be found on this object. Verify that the property exists and can be set."
At line:384 char:4
+             $psPASSession.LastCommandTime = Get-Date
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], SetValueInvocationException
    + FullyQualifiedErrorId : ExceptionWhenSetting

# laroberts in wksta
 ➜  Get-Module -ListAvailable -Name psPAS


    Directory: C:\Program Files\WindowsPowerShell\Modules


ModuleType Version    Name                                ExportedCommands
---------- -------    ----                                ----------------
Script     6.4.85     psPAS                               {New-PASSession, Close-PASSession, Add-PASPublicSSHKey, Get-PASPublicSSHKey...}


# laroberts in wksta
 ➜
```