### PR TITLE
Add logonToken parameter to Platform scripts

### DIFF
--- a/Platforms/Get-PlatformDetails.ps1
+++ b/Platforms/Get-PlatformDetails.ps1
@@ -24,11 +24,15 @@ param
 
 	[Parameter(Mandatory=$false,HelpMessage="Enter the Authentication type (Default:CyberArk)")]
 	[ValidateSet("cyberark","ldap","radius")]
-	[String]$AuthType="cyberark",	
-	
+	[String]$AuthType="cyberark",
+
 	[Parameter(Mandatory=$true,HelpMessage="Enter the platform ID to export")]
 	[Alias("id")]
-	[string]$PlatformID
+	[string]$PlatformID,
+
+    # Use this parameter to pass a pre-existing authorization token. If passed the token is NOT logged off
+    [Parameter(Mandatory = $false)]
+    $logonToken
 )
 
 # Global URLS
@@ -45,7 +49,6 @@ $URL_PlatformDetails = $URL_PVWAAPI+"/Platforms/{0}"
 # Initialize Script Variables
 # ---------------------------
 $rstusername = $rstpassword = ""
-$logonToken  = ""
 
 #region Functions
 Function Test-CommandExists
@@ -90,41 +93,52 @@ If (Test-CommandExists Invoke-RestMethod)
     }
 
 #region [Logon]
-    # Get Credentials to Login
-    # ------------------------
     $caption = "Get accounts"
-    $msg = "Enter your User name and Password"; 
-    $creds = $Host.UI.PromptForCredential($caption,$msg,"","")
-	if ($null -ne $creds)
-	{
-		$rstusername = $creds.username.Replace('\','');    
-		$rstpassword = $creds.GetNetworkCredential().password
-	}
-	else { exit }
-
-    # Create the POST Body for the Logon
-    # ----------------------------------
-    $logonBody = @{ username=$rstusername;password=$rstpassword }
-    $logonBody = $logonBody | ConvertTo-Json
-	try{
-	    # Logon
-	    $logonToken = Invoke-RestMethod -Method Post -Uri $URL_Logon -Body $logonBody -ContentType "application/json"
-	}
-	catch
-	{
-		Write-Host -ForegroundColor Red $_.Exception.Response.StatusDescription
-		$logonToken = ""
-	}
-    If ($logonToken -eq "")
-    {
-        Write-Host -ForegroundColor Red "Logon Token is Empty - Cannot login"
-        exit
+	if (![string]::IsNullOrEmpty($logonToken)) {
+        if ($logonToken.GetType().name -eq 'String') {
+            $logonHeader = @{Authorization = $logonToken }
+        }
+        else {
+            $logonHeader = $logonToken
+        }
     }
-	
-    # Create a Logon Token Header (This will be used through out all the script)
-    # ---------------------------
-    $logonHeader =  New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-    $logonHeader.Add("Authorization", $logonToken)
+	else
+	{
+		# Get Credentials to Login
+    	# ------------------------
+		$msg = "Enter your User name and Password";
+		$creds = $Host.UI.PromptForCredential($caption, $msg, "", "")
+		if ($null -ne $creds)
+		{
+			$rstusername = $creds.username.Replace('\', '');
+			$rstpassword = $creds.GetNetworkCredential().password
+		}
+		else { exit }
+
+		# Create the POST Body for the Logon
+		# ----------------------------------
+		$logonBody = @{ username = $rstusername; password = $rstpassword }
+		$logonBody = $logonBody | ConvertTo-Json
+		try{
+			# Logon
+			$logonToken = Invoke-RestMethod -Method Post -Uri $URL_Logon -Body $logonBody -ContentType "application/json"
+		}
+		catch
+		{
+			Write-Host -ForegroundColor Red $_.Exception.Response.StatusDescription
+			$logonToken = ""
+		}
+		If ($logonToken -eq "")
+		{
+			Write-Host -ForegroundColor Red "Logon Token is Empty - Cannot login"
+			exit
+		}
+
+		# Create a Logon Token Header (This will be used through out all the script)
+		# ---------------------------
+		$logonHeader = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
+		$logonHeader.Add("Authorization", $logonToken)
+	}
 #endregion
 
 #region Get Platform details
@@ -137,18 +151,24 @@ If (Test-CommandExists Invoke-RestMethod)
 		{
 			Write-verbose $platformDetails
 			Write-Host "$($platformDetails.Details.PolicyName) (ID: $($platformDetails.PlatformID)) is currently $(if($platformDetails.Active) { "Activated" } else { "Inactive" })"
-			Write-Host "Platform details:" 
-			$platformDetails.Details | Select-Object PolicyID, AllowedSafes, AllowManualChange, PerformPeriodicChange, @{Name = 'AllowManualVerification'; Expression = { $_.VFAllowManualVerification}}, @{Name = 'PerformPeriodicVerification'; Expression = { $_.VFPerformPeriodicVerification}}, @{Name = 'AllowManualReconciliation'; Expression = { $_.RCAllowManualReconciliation}}, @{Name = 'PerformAutoReconcileWhenUnsynced'; Expression = { $_.RCAutomaticReconcileWhenUnsynched}}, PasswordLength, MinUpperCase, MinLowerCase, MinDigit, MinSpecial 
-		}		
+			Write-Host "Platform details:"
+			$platformDetails.Details | Select-Object PolicyID, AllowedSafes, AllowManualChange, PerformPeriodicChange, @{Name = 'AllowManualVerification'; Expression = { $_.VFAllowManualVerification}}, @{Name = 'PerformPeriodicVerification'; Expression = { $_.VFPerformPeriodicVerification}}, @{Name = 'AllowManualReconciliation'; Expression = { $_.RCAllowManualReconciliation}}, @{Name = 'PerformAutoReconcileWhenUnsynced'; Expression = { $_.RCAutomaticReconcileWhenUnsynched}}, PasswordLength, MinUpperCase, MinLowerCase, MinDigit, MinSpecial
+		}
 	} catch {
 		Write-Error $_.Exception.Response
 		Write-Error $_.Exception.Response.StatusDescription
 	}
 #endregion
 	# Logoff the session
-    # ------------------
-    Write-Host "Logoff Session..."
-    Invoke-RestMethod -Method Post -Uri $URL_Logoff -Headers $logonHeader -ContentType "application/json" | Out-Null
+	If (![string]::IsNullOrEmpty($logonToken)) {
+		Write-Host 'LogonToken passed, session NOT logged off'
+	}
+	else {
+		# Logoff the session
+		# ------------------
+		Write-Host "Logoff Session..."
+		Invoke-RestMethod -Method Post -Uri $URL_Logoff -Headers $logonHeader -ContentType "application/json" | Out-Null
+	}
 }
 else
 {

--- a/Platforms/Get-PlatformDetails.ps1
+++ b/Platforms/Get-PlatformDetails.ps1
@@ -30,9 +30,9 @@ param
 	[Alias("id")]
 	[string]$PlatformID,
 
-    # Use this parameter to pass a pre-existing authorization token. If passed the token is NOT logged off
-    [Parameter(Mandatory = $false)]
-    $logonToken
+	# Use this parameter to pass a pre-existing authorization token. If passed the token is NOT logged off
+	[Parameter(Mandatory = $false)]
+	$logonToken
 )
 
 # Global URLS

--- a/Platforms/Get-PlatformDetails.ps1
+++ b/Platforms/Get-PlatformDetails.ps1
@@ -24,8 +24,8 @@ param
 
 	[Parameter(Mandatory=$false,HelpMessage="Enter the Authentication type (Default:CyberArk)")]
 	[ValidateSet("cyberark","ldap","radius")]
-	[String]$AuthType="cyberark",
-
+	[String]$AuthType="cyberark",	
+	
 	[Parameter(Mandatory=$true,HelpMessage="Enter the platform ID to export")]
 	[Alias("id")]
 	[string]$PlatformID,

--- a/Platforms/Get-PlatformReport.ps1
+++ b/Platforms/Get-PlatformReport.ps1
@@ -543,8 +543,6 @@ $caption = "Platforms Report"
 
 #region [Logon]
 try {
-	# Get Credentials to Login
-	# ------------------------
 	If (![string]::IsNullOrEmpty($logonToken)) {
 		if ($logonToken.GetType().name -eq 'String') {
 			$logonHeader = @{Authorization = $logonToken }
@@ -555,6 +553,8 @@ try {
 		}
 	}
 	elseif ($null -eq $creds) {
+		# Get Credentials to Login
+		# ------------------------
 		$msg = "Enter your PAS User name and Password ($AuthType)";
 		$creds = $Host.UI.PromptForCredential($caption,$msg,"","")
 		Get-LogonHeader -Credentials $creds

--- a/Platforms/Get-PlatformReport.ps1
+++ b/Platforms/Get-PlatformReport.ps1
@@ -38,7 +38,11 @@ param
 	
 	[Parameter(Mandatory=$false,HelpMessage="Path to a CSV file to export data to")]
 	[Alias("path")]
-	[string]$CSVPath
+	[string]$CSVPath,
+
+	# Use this parameter to pass a pre-existing authorization token. If passed the token is NOT logged off
+	[Parameter(Mandatory = $false)]
+	$logonToken
 )
 
 # Get Script Location 
@@ -536,9 +540,35 @@ else
 # Get Credentials to Login
 # ------------------------
 $caption = "Platforms Report"
-$msg = "Enter your PAS User name and Password ($AuthType)"; 
-$creds = $Host.UI.PromptForCredential($caption,$msg,"","")
 
+#region [Logon]
+try {
+	# Get Credentials to Login
+	# ------------------------
+	If (![string]::IsNullOrEmpty($logonToken)) {
+		if ($logonToken.GetType().name -eq 'String') {
+			$logonHeader = @{Authorization = $logonToken }
+			Set-Variable -Name g_LogonHeader -Value $logonHeader -Scope global
+		}
+		else {
+			Set-Variable -Name g_LogonHeader -Value $logonToken -Scope global
+		}
+	}
+	elseif ($null -eq $creds) {
+		$msg = "Enter your PAS User name and Password ($AuthType)";
+		$creds = $Host.UI.PromptForCredential($caption,$msg,"","")
+		Get-LogonHeader -Credentials $creds
+	}
+	else {
+		Write-LogMessage -type Error -MSG 'No Credentials were entered'
+		return
+	}
+}
+catch {
+	Write-LogMessage -type Error -MSG "Error Logging on. Error: $(Join-ExceptionMessage $_.Exception)"
+	return
+}
+#endregion
 
 #region Get all active Platforms
 try{
@@ -549,7 +579,7 @@ try{
 	} else {
 		$urlActivePlatforms = $URL_TargetPlatforms
 	}
-	$activePlatforms = Invoke-Rest -Command Get -Uri $urlActivePlatforms -Header $(Get-LogonHeader -Credentials $creds)
+	$activePlatforms = Invoke-Rest -Command Get -Uri $urlActivePlatforms -Header $g_LogonHeader
 	If($activePlatforms)
 	{
 		Write-LogMessage -Type Info -Msg "Found $($activePlatforms.Total) active Platforms"
@@ -557,7 +587,7 @@ try{
 		Write-LogMessage -Type Debug -Msg "Getting Platfroms PSM Connectors information"
 		ForEach($platform in $activePlatforms.Platforms)
 		{
-			$psmServerTargetInfo = Invoke-REST -Command Get -Uri ($URL_TargetPlatformPSMConnectors -f $platform.id) -Header (Get-LogonHeader -Credentials $creds)
+			$psmServerTargetInfo = Invoke-REST -Command Get -Uri ($URL_TargetPlatformPSMConnectors -f $platform.id) -Header $g_LogonHeader
 			if($null -ne $platform.PrivilegedSessionManagement)
 			{
 				$platform.PrivilegedSessionManagement | Add-Member -NotePropertyName PSMConnectors -NotePropertyValue $psmServerTargetInfo.PSMConnectors
@@ -612,4 +642,9 @@ try{
 }
 #endregion
 # Logoff the session
-Run-Logoff
+If (![string]::IsNullOrEmpty($logonToken)) {
+	Write-Host 'LogonToken passed, session NOT logged off'
+}
+else {
+	Run-Logoff
+}


### PR DESCRIPTION
### Desired Outcome

This PR adds a `logonToken` parameter to the scripts:
1. `Platforms/Get-PlatformDetails.ps1`
2.  `Platforms/Get-PlatformReport.ps1`

This addition enables passing a pre-existing authorization token to support ISPSS authentication.

### Implemented Changes
- **What's changed?**
  - Added a `logonToken` parameter to the relevant scripts to facilitate the use of pre-existing ISPSS authorization tokens.

- **How should the reviewer approach this PR?**
  - Review the script modifications ensuring the new `logonToken` parameter is properly integrated.
  - The changes have already been manually tested on an ISPSS environment with the `logonToken` provided, confirming proper functionality.
  - The reviewer should consider to also manually test execution of the scripts **without** providing the `logonToken`, ensuring that existing authorization behaviors remain unaffected.